### PR TITLE
the flush command now removes all matching keys from all enpoints

### DIFF
--- a/src/Dewey.Azure/project.json
+++ b/src/Dewey.Azure/project.json
@@ -1,5 +1,5 @@
 ﻿{
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "A collection of .Net utilities for Azure",
     "authors": [
         "Axial Commerce <contact@axialcommerce.com>"

--- a/src/Dewey.Json/project.json
+++ b/src/Dewey.Json/project.json
@@ -1,5 +1,5 @@
 ﻿{
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "A collection of .Net utilities for Json",
     "authors": [
         "Axial Commerce <contact@axialcommerce.com>"

--- a/src/Dewey.Redis/Cache.cs
+++ b/src/Dewey.Redis/Cache.cs
@@ -9,7 +9,6 @@ namespace Dewey.Redis
     public static class Cache
     {
         private static IDatabase _cache => lazyConnection.Value.GetDatabase();
-        private static IServer _server => lazyConnection.Value.GetServer(ConnectionString);
 
         public static int SlidingExpirationMinutes = 30;
 
@@ -101,9 +100,11 @@ namespace Dewey.Redis
                 throw new Exception("Flushing by pattern requires Admin mode.");
             }
 
-            var keys = _server.Keys(pattern: pattern).ToArray();
+            foreach (var endpoint in lazyConnection.Value.GetEndPoints()) {
+                var keys = lazyConnection.Value.GetServer(endpoint).Keys(pattern: pattern).ToArray();
 
-            await _cache.KeyDeleteAsync(keys, CommandFlags.FireAndForget);
+                await lazyConnection.Value.GetDatabase().KeyDeleteAsync(keys);
+            }
         }
     }
 }

--- a/src/Dewey.Redis/project.json
+++ b/src/Dewey.Redis/project.json
@@ -1,5 +1,5 @@
 ﻿{
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "A collection of .Net utilities for Redis",
     "authors": [
         "Axial Commerce <contact@axialcommerce.com>"

--- a/src/Dewey/project.json
+++ b/src/Dewey/project.json
@@ -1,5 +1,5 @@
 ﻿{
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "A collection of .Net utilities",
     "authors": [
         "Axial Commerce <contact@axialcommerce.com>"


### PR DESCRIPTION
I removed the fire and forget flag from the delete call in the flush method. 

The flush method also removes any keys matching the pattern from all connected end points so now if we scale the cache across multiple end points it will flush based on the pattern at every end point.

I also updated the minor version of all of the packages so everything is now 1.0.5